### PR TITLE
Bump UUID package version to ^10

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@swc/core": "^1.4.6",
     "@types/luxon": "^3.4.2",
     "@types/node": "^20.11.25",
-    "@types/uuid": "^9.0.8",
+    "@types/uuid": "^10.0.0",
     "c8": "^9.1.0",
     "copyfiles": "^2.4.1",
     "del-cli": "^5.1.0",
@@ -64,14 +64,14 @@
     "sqlite3": "^5.1.7",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
-    "uuid": "^9.0.1"
+    "uuid": "^10.0.0"
   },
   "peerDependencies": {
     "@adonisjs/core": "^6.2.0",
     "@adonisjs/lucid": "^21.0.0",
     "@types/uuid": "^9.0.8",
     "luxon": "^3.4.4",
-    "uuid": "^9.0.1"
+    "uuid": "^10.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Bumped `uuid` package to `^10` version, unless there's something specific you need from `^9`, I don't see a reason to not use the higher version.

Also it blocks installation for me, since I'm using `uuid ^10` in my project.